### PR TITLE
Bundle CMB as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/custom-meta-boxes"]
+	path = lib/custom-meta-boxes
+	url = git@github.com:humanmade/Custom-Meta-Boxes.git

--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,12 @@ add_action( 'widgets_init',       __NAMESPACE__ . '\\widgets_init' );
 
 require_once( __DIR__ . '/inc/events/events.php' );
 
+if ( ! function_exists( 'cmb_init' ) ) {
+	define( 'CMB_PATH', __DIR__ . '/lib/custom-meta-boxes' );
+	define( 'CMB_URL', get_stylesheet_directory_uri() . '/lib/custom-meta-boxes' );
+	require_once( 'lib/custom-meta-boxes/custom-meta-boxes.php' );
+}
+
 /**
  * Set up the theme.
  */


### PR DESCRIPTION
This is currently a requirement of the theme. I can bundle in the theme so this doesn't have to be installed separately.
